### PR TITLE
Do not perform a pod install as part of CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
   - LANG=en_US.UTF-8
 install:
 - bundle install --jobs=3
-- bundle exec pod install
 script:
 - rake run_tests
 - rake build_examples


### PR DESCRIPTION
This will ensure that the project can be run without CocoaPods installed
