### PR TITLE
Order symbols alphabetically.

### DIFF
--- a/MotifCLI/MotifCLI/MTFTheme+SymbolsGeneration.m
+++ b/MotifCLI/MotifCLI/MTFTheme+SymbolsGeneration.m
@@ -274,6 +274,7 @@ static NSString * const WarningCommentFormat = @"\
     if (!symbols || !symbols.count) {
         return nil;
     }
+    symbols = [symbols sortedArrayUsingSelector:@selector(compare:)];
     
     NSMutableArray *lines = [NSMutableArray new];
  


### PR DESCRIPTION
Change the CLI to output sorted symbols, to reduce diff noise when editing themes.

The theme symbols are currently output in some non-deterministic way due to being saved in the unordered `NSDictionary`. Since we're using the builtin JSON parser and there's no simple way to impose an ordering from the input JSON, alphabetical sort seemed like a good thing.
