### PR TITLE
Add -k option to avoid touching unmodified files.

### DIFF
--- a/Examples/ButtonsExample.xcodeproj/project.pbxproj
+++ b/Examples/ButtonsExample.xcodeproj/project.pbxproj
@@ -225,7 +225,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = "/bin/sh -x";
-			shellScript = "export PATH=\"$PATH:/usr/local/bin\"\nexport CLI_TOOL='motif'\n\nwhich \"${CLI_TOOL}\"\n\nif [ $? -ne 0  ]; then exit 0; fi\n\nexport THEMES_DIR=\"${SRCROOT}/${PRODUCT_NAME}\"\n\nfind \"${THEMES_DIR}\" -name '*Theme.json' |  sed 's/^/-t /' | xargs \"${CLI_TOOL}\" -o \"${THEMES_DIR}\"";
+			shellScript = "export PATH=\"$PATH:/usr/local/bin\"\nexport CLI_TOOL='motif'\n\nwhich \"${CLI_TOOL}\"\n\nif [ $? -ne 0  ]; then exit 0; fi\n\nexport THEMES_DIR=\"${SRCROOT}/${PRODUCT_NAME}\"\n\nfind \"${THEMES_DIR}\" -name '*Theme.json' |  sed 's/^/-t /' | xargs \"${CLI_TOOL}\" -k -o \"${THEMES_DIR}\"";
 			showEnvVarsInLog = 0;
 		};
 		73C0CA75FBABAB354BAB437B /* Check Pods Manifest.lock */ = {

--- a/Examples/DynamicThemingExample.xcodeproj/project.pbxproj
+++ b/Examples/DynamicThemingExample.xcodeproj/project.pbxproj
@@ -503,7 +503,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=\"$PATH:/usr/local/bin\"\nexport CLI_TOOL='motif'\n\nwhich \"${CLI_TOOL}\"\n\nif [ $? -ne 0  ]; then exit 0; fi\n\nexport THEMES_DIR=\"${SRCROOT}/DynamicThemingExample/Themes\"\nexport OUTPUT_DIR=\"${SRCROOT}/DynamicThemingExample/ThemeSymbols\"\n\nfind \"${THEMES_DIR}\" -name '*Theme.json' | rm\nfind \"${THEMES_DIR}\" -name '*Theme.json' |  sed 's/^/-t /' | xargs \"${CLI_TOOL}\" -o \"${OUTPUT_DIR}\"";
+			shellScript = "export PATH=\"$PATH:/usr/local/bin\"\nexport CLI_TOOL='motif'\n\nwhich \"${CLI_TOOL}\"\n\nif [ $? -ne 0  ]; then exit 0; fi\n\nexport THEMES_DIR=\"${SRCROOT}/DynamicThemingExample/Themes\"\nexport OUTPUT_DIR=\"${SRCROOT}/DynamicThemingExample/ThemeSymbols\"\n\nfind \"${THEMES_DIR}\" -name '*Theme.json' | rm\nfind \"${THEMES_DIR}\" -name '*Theme.json' |  sed 's/^/-t /' | xargs \"${CLI_TOOL}\" -k -o \"${OUTPUT_DIR}\"";
 			showEnvVarsInLog = 0;
 		};
 		4C45BAE8C74767A37A925E3E /* Check Pods Manifest.lock */ = {

--- a/MotifCLI/MotifCLI/GBOptionsHelper+ThemingSymbolsGenerator.m
+++ b/MotifCLI/MotifCLI/GBOptionsHelper+ThemingSymbolsGenerator.m
@@ -46,6 +46,12 @@
         long:MTFSettingsOptionVerbose
         description:@"Print output verbosely when executing."
         flags:GBOptionNoValue];
+
+    [self registerOption:'k'
+        long:MTFSettingsOptionModification
+        description:@"Don't touch files which haven't changed."
+        flags:GBOptionNoValue];
+
 }
 
 @end

--- a/MotifCLI/MotifCLI/GBSettings+ThemingSymbolsGenerator.h
+++ b/MotifCLI/MotifCLI/GBSettings+ThemingSymbolsGenerator.h
@@ -15,6 +15,7 @@ extern NSString * const MTFSettingsOptionTabs;
 extern NSString * const MTFSettingsOptionIndentationCount;
 extern NSString * const MTFSettingsOptionHelp;
 extern NSString * const MTFSettingsOptionVerbose;
+extern NSString * const MTFSettingsOptionModification;
 
 @interface GBSettings (ThemingSymbolsGenerator)
 
@@ -35,6 +36,8 @@ extern NSString * const MTFSettingsOptionVerbose;
 @property (nonatomic, setter=mtf_setHelp:) BOOL mtf_help;
 
 @property (nonatomic, setter=mtf_setVerbose:) BOOL mtf_verbose;
+
+@property (nonatomic, setter=mtf_setCheckForModification:) BOOL mtf_checkForModification;
 
 #pragma mark - Derived Properties
 

--- a/MotifCLI/MotifCLI/GBSettings+ThemingSymbolsGenerator.m
+++ b/MotifCLI/MotifCLI/GBSettings+ThemingSymbolsGenerator.m
@@ -15,6 +15,7 @@ NSString * const MTFSettingsOptionTabs = @"tabs";
 NSString * const MTFSettingsOptionIndentationCount = @"indentation-count";
 NSString * const MTFSettingsOptionHelp = @"help";
 NSString * const MTFSettingsOptionVerbose = @"verbose";
+NSString * const MTFSettingsOptionModification = @"keep";
 
 @implementation GBSettings (MTFThemingSymbolsGenerator)
 
@@ -31,6 +32,7 @@ NSString * const MTFSettingsOptionVerbose = @"verbose";
     self.mtf_prefix = @"";
     self.mtf_shouldIndentUsingTabs = NO;
     self.mtf_indentationCount = 4;
+    self.mtf_checkForModification = NO;
 }
 
 GB_SYNTHESIZE_OBJECT(NSArray *, mtf_themes, mtf_setThemes, MTFSettingsOptionThemes)
@@ -40,6 +42,7 @@ GB_SYNTHESIZE_BOOL(mtf_shouldIndentUsingTabs, mtf_setShouldIndentUsingTabs, MTFS
 GB_SYNTHESIZE_INT(mtf_indentationCount, mtf_setIndentationCount, MTFSettingsOptionIndentationCount)
 GB_SYNTHESIZE_BOOL(mtf_help, mtf_setHelp, MTFSettingsOptionHelp)
 GB_SYNTHESIZE_BOOL(mtf_verbose, mtf_setVerbose, MTFSettingsOptionVerbose)
+GB_SYNTHESIZE_BOOL(mtf_checkForModification, mtf_setCheckForModification, MTFSettingsOptionModification)
 
 #pragma mark - Derived Properties
 

--- a/MotifCLI/MotifCLI/MTFTheme+SymbolsGeneration.h
+++ b/MotifCLI/MotifCLI/MTFTheme+SymbolsGeneration.h
@@ -10,9 +10,9 @@
 
 @interface MTFTheme (SymbolsGeneration)
 
-- (void)generateSymbolsFilesInDirectory:(NSURL *)directoryURL indentation:(NSString *)indentation prefix:(NSString *)prefix;
+- (void)generateSymbolsFilesInDirectory:(NSURL *)directoryURL indentation:(NSString *)indentation prefix:(NSString *)prefix checkForModification:(BOOL)checkForModification;
 
-+ (void)generateSymbolsUmbrellaHeaderFromThemes:(NSArray *)themes inDirectory:(NSURL *)directoryURL prefix:(NSString *)prefix;
++ (void)generateSymbolsUmbrellaHeaderFromThemes:(NSArray *)themes inDirectory:(NSURL *)directoryURL prefix:(NSString *)prefix checkForModification:(BOOL)checkForModification;
 
 @property (nonatomic, readonly) NSArray *constantKeys;
 @property (nonatomic, readonly) NSArray *classNames;

--- a/MotifCLI/MotifCLI/MTFTheme+SymbolsGeneration.m
+++ b/MotifCLI/MotifCLI/MTFTheme+SymbolsGeneration.m
@@ -73,7 +73,11 @@ typedef NS_ENUM(NSInteger, SymbolType) {
     [outputStream close];
 
     NSData *data = [outputStream propertyForKey:NSStreamDataWrittenToMemoryStreamKey];
-    [self.class outputData:data toFileNamed:outputFilename inDirectory:directoryURL checkForModification:checkForModification];
+    [self.class
+        outputData:data
+        toFileNamed:outputFilename
+        inDirectory:directoryURL
+        checkForModification:checkForModification];
 
     gbprintln(@"Generated: %@", outputFilename);
 }
@@ -156,7 +160,11 @@ typedef NS_ENUM(NSInteger, SymbolType) {
     [outputStream close];
 
     NSData *data = [outputStream propertyForKey:NSStreamDataWrittenToMemoryStreamKey];
-    [self.class outputData:data toFileNamed:outputFilename inDirectory:directoryURL checkForModification:checkForModification];
+    [self.class
+        outputData:data
+        toFileNamed:outputFilename
+        inDirectory:directoryURL
+        checkForModification:checkForModification];
 
     gbprintln(@"Generated: %@", outputFilename);
 }

--- a/MotifCLI/MotifCLI/MTFThemingSymbolsGenerator.m
+++ b/MotifCLI/MotifCLI/MTFThemingSymbolsGenerator.m
@@ -63,7 +63,8 @@
         [theme
             generateSymbolsFilesInDirectory:outputDirectoryURL
             indentation:settings.mtf_indentation
-            prefix:settings.mtf_prefix];
+            prefix:settings.mtf_prefix
+            checkForModification:settings.mtf_checkForModification];
     }
     
     // If there is more than one theme, generate an umbrella header to enable
@@ -72,7 +73,8 @@
         [MTFTheme
             generateSymbolsUmbrellaHeaderFromThemes:themes
             inDirectory:outputDirectoryURL
-            prefix:settings.mtf_prefix];
+            prefix:settings.mtf_prefix
+            checkForModification:settings.mtf_checkForModification];
     }
     
     return 0;


### PR DESCRIPTION
:confused: May not be a reasonable feature.

Added `-k` option to CLI so that themes that haven't changed leave the headers unmodified. Without this, it's more of a pain to stop Xcode rebuilding the entire UI code every every build, if you're using a build phase to run the CLI.

Something similar could be accomplished with a file modification time check, without the disadvantage of building each file completely in memory before output, but I don't expect theme symbols to be huge.
