### PR TITLE
Handle duplicate appliers with different classes

### DIFF
--- a/Motif/Core/MTFThemeClassApplicable.h
+++ b/Motif/Core/MTFThemeClassApplicable.h
@@ -36,7 +36,7 @@ MTF_NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSArray *properties;
 
 /**
- Returns whether the receiving applier should be used apply the properties in
+ Returns whether the receiving applier should be used to apply the properties in
  the specified class to an object.
  
  @param class The theme class that is being querying for application.

--- a/Motif/Core/MTFThemeClassApplicable.m
+++ b/Motif/Core/MTFThemeClassApplicable.m
@@ -10,6 +10,7 @@
 #import "MTFThemeClassApplicable.h"
 #import "MTFThemeConstant.h"
 #import "MTFThemeClass_Private.h"
+#import "MTFReverseTransformedValueClass.h"
 
 @implementation MTFThemeClassApplier
 
@@ -50,8 +51,8 @@
     self.applierBlock(class, object);
 }
 
-- (BOOL)shouldApplyClass:(MTFThemeClass *)class {
-    NSParameterAssert(class);
+- (BOOL)shouldApplyClass:(MTFThemeClass *)themeClass {
+    NSParameterAssert(themeClass);
     
     return YES;
 }
@@ -92,7 +93,7 @@
 
 + (id)valueFromConstant:(MTFThemeConstant *)constant forProperty:(NSString *)property onObject:(id <NSObject>)object withRequiredClass:(Class)requiredClass valueTransformerName:(NSString *)valueTransformerName {
     NSAssert(constant, @"Constant must not be nil");
-    id <NSObject> value = constant.value;
+    id<NSObject> value = constant.value;
     
     // Enforce required class if necessary
     if (requiredClass) {
@@ -101,16 +102,31 @@
             __unused NSString *applierClassName = NSStringFromClass(object.class);
             __unused NSString *requiredClassName = NSStringFromClass(requiredClass);
             __unused NSString *valueClassName = NSStringFromClass(value.class);
-            NSAssert(isValueOfRequiredClass, @"The theme applier on '%@' requires that the value for property '%@' is of class '%@'. It is instead an instace of '%@'", applierClassName, property, requiredClassName, valueClassName);
+
+            NSAssert(
+                isValueOfRequiredClass,
+                @"The theme applier on '%@' requires that the value for "
+                    "property '%@' is of class '%@'. It is instead an instace "
+                    "of '%@'.",
+                applierClassName,
+                property,
+                requiredClassName,
+                valueClassName);
         }
     }
     
     // Transform value if necessary
     if (valueTransformerName) {
         __unused NSValueTransformer *valueTransformer = [NSValueTransformer valueTransformerForName:valueTransformerName];
-        NSAssert(valueTransformer, @"There is no value transfomer registered for the name '%@'. Before applying a theme, you must first register a value transformer instance using `+[NSValueTransformer setValueTransformer:forName:]` for the specified name.", valueTransformerName);
-        id transformedValue = [constant
-            transformedValueFromTransformerWithName:valueTransformerName];
+
+        NSAssert(
+            valueTransformer,
+            @"There is no value transfomer registered for the name '%@'. "
+                "Before applying a theme, you must first register a value "
+                "transformer instance for the specified name.",
+            valueTransformerName);
+
+        id transformedValue = [constant transformedValueFromTransformerWithName:valueTransformerName];
         value = transformedValue;
     }
     
@@ -129,8 +145,7 @@
     NSParameterAssert(class);
     NSParameterAssert(object);
     
-    MTFThemeConstant *constant = class.
-        resolvedPropertiesConstants[self.property];
+    MTFThemeConstant *constant = class.resolvedPropertiesConstants[self.property];
     
     id value = [self.class
         valueFromConstant:constant
@@ -142,8 +157,52 @@
     self.applierBlock(value, object);
 }
 
-- (BOOL)shouldApplyClass:(MTFThemeClass *)class {
-    return [class.properties.allKeys containsObject:self.property];
+- (BOOL)shouldApplyClass:(MTFThemeClass *)themeClass {
+    NSParameterAssert(themeClass);
+
+    return [self.class
+        shouldApplyClass:themeClass
+        forProperty:self.property
+        requiredClass:self.requiredClass
+        withValueTransformerName:self.valueTransformerName];
+}
+
++ (BOOL)shouldApplyClass:(MTFThemeClass *)class forProperty:(NSString *)property requiredClass:(Class)requiredClass withValueTransformerName:(NSString *)valueTransformerName {
+    NSParameterAssert(class);
+    NSParameterAssert(property);
+
+    id propertyValue = class.properties[property];
+
+    // If there is neither a value transformer nor a required class, this class
+    // can be applied our property exists in the required class dictionary
+    if (valueTransformerName == nil && requiredClass == Nil) {
+        return (propertyValue != nil);
+    }
+    // Otherwise, if we have a value transformer that implements
+    // MTFReverseTransformedValueClass, check if it can transform this value
+    else if (valueTransformerName != nil) {
+        NSValueTransformer *transformer = [NSValueTransformer valueTransformerForName:valueTransformerName];
+
+        NSAssert(
+            transformer != nil,
+            @"Unable to locate value transformer for with name '%@' for theme "
+                "applier with property name '%@'.",
+            valueTransformerName,
+            property);
+
+        if (![transformer conformsToProtocol:@protocol(MTFReverseTransformedValueClass)] && propertyValue) {
+            return YES;
+        }
+
+        Class requiredValueClass = [((id<MTFReverseTransformedValueClass>)transformer).class reverseTransformedValueClass];
+
+        return [propertyValue isKindOfClass:requiredValueClass];
+    }
+    else if (requiredClass != Nil) {
+        return [propertyValue isKindOfClass:requiredClass];
+    }
+
+    return NO;
 }
 
 @end
@@ -163,7 +222,7 @@
 #pragma clang diagnostic pop
 }
 
-#pragma mark - MTFThemeClassPropertyApplier
+#pragma mark - MTFThemeClassPropertiesApplier
 
 - (instancetype)initWithProperties:(NSArray *)properties valueTransformersOrRequiredClasses:(NSArray *)valueTransformersOrRequiredClasses applierBlock:(MTFThemePropertiesApplierBlock)applierBlock {
     NSParameterAssert(properties);
@@ -203,7 +262,7 @@
     return nil;
 }
 
-#pragma mark - MTFThemeClassPropertyApplier <MTFThemeClassApplicable>
+#pragma mark - MTFThemeClassPropertiesApplier <MTFThemeClassApplicable>
 
 @synthesize properties = _properties;
 
@@ -217,14 +276,11 @@
         NSString *property,
         NSUInteger propertyIndex,
         BOOL *_) {
-            MTFThemeConstant *constant = class.
-                resolvedPropertiesConstants[property];
+            MTFThemeConstant *constant = class.resolvedPropertiesConstants[property];
         
-            Class requiredClass = [self
-                requiredClassForPropertyAtIndex:propertyIndex];
-        
-            NSString *valueTransformerName = [self
-                valueTransformerNameForPropertyAtIndex:propertyIndex];
+            Class requiredClass = [self requiredClassForPropertyAtIndex:propertyIndex];
+
+            NSString *valueTransformerName = [self valueTransformerNameForPropertyAtIndex:propertyIndex];
         
             id value = [MTFThemeClassPropertyApplier
                 valueFromConstant:constant
@@ -232,17 +288,47 @@
                 onObject:object
                 withRequiredClass:requiredClass
                 valueTransformerName:valueTransformerName];
-        
+
             valuesForProperties[property] = value;
         }];
     
     self.applierBlock([valuesForProperties copy], object);
 }
 
-- (BOOL)shouldApplyClass:(MTFThemeClass *)class {
-    NSSet *classProperties = [NSSet setWithArray:class.properties.allKeys];
+- (BOOL)shouldApplyClass:(MTFThemeClass *)themeClass {
+    NSParameterAssert(themeClass);
+
     NSSet *applierProperties = [NSSet setWithArray:self.properties];
-    return [classProperties intersectsSet:applierProperties];
+
+    // Build a list of the applier properties that intersects with the class
+    // properties that is being queried to apply
+    NSMutableSet *propertiesIntersection = [NSMutableSet setWithArray:themeClass.properties.allKeys];
+    [propertiesIntersection intersectSet:applierProperties];
+
+    // If the intersection doesn't have the same number of entries as the
+    // applier has properties, do not apply, since a
+    // MTFThemeClassPropertiesApplier only applies when all its properties
+    // are present
+    if (propertiesIntersection.count != self.properties.count) {
+        return NO;
+    }
+
+    for (NSInteger index = 0; index < (NSInteger)self.properties.count; index++) {
+        Class requiredClass = [self requiredClassForPropertyAtIndex:index];
+        NSString *valueTransformerName = [self valueTransformerNameForPropertyAtIndex:index];
+
+        BOOL shouldApplyClass = [MTFThemeClassPropertyApplier
+            shouldApplyClass:themeClass
+            forProperty:self.properties[index]
+            requiredClass:requiredClass
+            withValueTransformerName:valueTransformerName];
+
+        if (!shouldApplyClass) {
+            return NO;
+        }
+    }
+
+    return YES;
 }
 
 @end

--- a/MotifTests/MTFThemeClassApplierTests.m
+++ b/MotifTests/MTFThemeClassApplierTests.m
@@ -16,6 +16,10 @@
 
 @end
 
+@interface MTFThemeClassApplierTestObject : NSObject
+
+@end
+
 @implementation MTFThemeClassApplierTests
 
 - (void)testClassApplier
@@ -30,13 +34,14 @@
         initWithThemeDictionary:rawTheme
         error:&error];
     XCTAssertNil(error, @"Error must be nil");
-    
-    NSObject *object = [NSObject new];
+
+    Class objectClass = MTFThemeClassApplierTestObject.class;
+    NSObject *object = [objectClass new];
     
     XCTestExpectation *expectation = [self
         expectationWithDescription:@"Theme class applier expectation"];
     
-    id <MTFThemeClassApplicable> classApplier = [NSObject
+    id <MTFThemeClassApplicable> classApplier = [objectClass
         mtf_registerThemeClassApplierBlock:^(MTFThemeClass *class, id objectToTheme) {
             XCTAssertEqual(object, objectToTheme, @"The object in the applier must the same object that has a theme applied to it");
             [expectation fulfill];
@@ -45,8 +50,12 @@
     [theme applyClassWithName:class.mtf_symbol toObject:object];
     
     [self waitForExpectationsWithTimeout:0.0 handler:^(NSError *error) {
-        [NSObject mtf_deregisterThemeClassApplier:classApplier];
+        [objectClass mtf_deregisterThemeClassApplier:classApplier];
     }];
 }
+
+@end
+
+@implementation MTFThemeClassApplierTestObject
 
 @end

--- a/MotifTests/MTFThemeLoadingTests.m
+++ b/MotifTests/MTFThemeLoadingTests.m
@@ -18,21 +18,13 @@
 
 #pragma mark - File Tests
 
-- (void)testNonFileURLIsInvalid
-{
-    XCTestExpectation *exceptionExpectation = [self
-        expectationWithDescription:@"Exception should be thrown when JSON file URL is invalid"];
-    
-    @try {
-        NSURL *URL = [NSURL URLWithString:@"http://www.google.com"];
-        __unused MTFTheme *theme = [[MTFTheme alloc]
-            initWithJSONFile:URL error:nil];
-    }
-    @catch (NSException *exception) {
-        [exceptionExpectation fulfill];
-    }
-    
-    [self waitForExpectationsWithTimeout:0.0 handler:nil];
+- (void)testNonFileURLIsInvalid {
+    NSURL *URL = [NSURL URLWithString:@"http://www.google.com"];
+
+    MTFTheme *theme;
+    XCTAssertThrows(
+        theme = [[MTFTheme alloc] initWithJSONFile:URL error:nil],
+        @"Exception should be thrown when JSON file URL is invalid");
 }
 
 - (void)testNonExistentFileURLIsInvalid
@@ -44,48 +36,27 @@
     
     NSUUID *UUID = [NSUUID new];
     
-    NSURL *fileURL = [documentsDirectory
-        URLByAppendingPathComponent:UUID.UUIDString];
-    
-    XCTestExpectation *exceptionExpectation = [self
-        expectationWithDescription:@"Exception should be thrown when JSON file URL is invalid"];
-    
-    @try {
-        __unused MTFTheme *theme = [[MTFTheme alloc]
-            initWithJSONFile:fileURL
-            error:nil];
-    }
-    @catch (NSException *exception) {
-        [exceptionExpectation fulfill];
-    }
-    
-    [self waitForExpectationsWithTimeout:0.0 handler:nil];
+    NSURL *fileURL = [documentsDirectory URLByAppendingPathComponent:UUID.UUIDString];
+
+    MTFTheme *theme;
+    XCTAssertThrows(
+        theme = [[MTFTheme alloc] initWithJSONFile:fileURL error:nil],
+        @"Exception should be thrown when JSON file URL is invalid");
 }
 
-- (void)testInvalidJSONFileIsInvalid
-{
+- (void)testInvalidJSONFileIsInvalid {
     NSBundle *bundle = [NSBundle bundleForClass:self.class];
     NSURL *fileURL = [bundle
         URLForResource:@"InvalidJSONTheme"
         withExtension:@"json"];
-    
-    XCTestExpectation *exceptionExpectation = [self
-        expectationWithDescription:@"Exception should be thrown when JSON file URL is invalid"];
-    
-    @try {
-        __unused MTFTheme *theme = [[MTFTheme alloc]
-            initWithJSONFile:fileURL
-            error:nil];
-    }
-    @catch (NSException *exception) {
-        [exceptionExpectation fulfill];
-    }
-    
-    [self waitForExpectationsWithTimeout:0.0 handler:nil];
+
+    MTFTheme *theme;
+    XCTAssertThrows(
+        theme = [[MTFTheme alloc] initWithJSONFile:fileURL error:nil],
+        @"Exception should be thrown when JSON file URL is invalid");
 }
 
-- (void)testJSONFileIsAdded
-{
+- (void)testJSONFileIsAdded {
     NSURL *fileURL = [[NSBundle bundleForClass:self.class] URLForResource:@"BasicTheme" withExtension:@"json"];
     
     NSError *error;
@@ -97,8 +68,7 @@
 
 #pragma mark - Theme Names
 
-- (void)testThemeNameMatchesFilename
-{
+- (void)testThemeNameMatchesFilename {
     NSString *themeName = @"Basic";
     NSBundle *bundle = [NSBundle bundleForClass:self.class];
     NSURL *fileURL = [bundle URLForResource:themeName withExtension:@"json"];
@@ -111,8 +81,7 @@
     XCTAssertEqualObjects(theme.names.firstObject, themeName, @"Theme must contain filename without extension");
 }
 
-- (void)testThemeNameMatchesFilenameAndTrimsTheme
-{
+- (void)testThemeNameMatchesFilenameAndTrimsTheme {
     NSString *themeName = @"Basic";
     NSString *themeFilename = [NSString stringWithFormat:@"%@Theme", themeName];
     NSBundle *bundle = [NSBundle bundleForClass:self.class];
@@ -126,8 +95,7 @@
     XCTAssertEqualObjects(theme.names.firstObject, themeName, @"Theme must contain filename without extension");
 }
 
-- (void)testThemeNameMatchesFilenameWithoutExtension
-{
+- (void)testThemeNameMatchesFilenameWithoutExtension {
     NSString *themeName = @"BasicThemeWithNoExtension";
     NSBundle *bundle = [NSBundle bundleForClass:self.class];
     NSURL *fileURL = [bundle URLForResource:themeName withExtension:nil];


### PR DESCRIPTION
This handles the case where duplicate appliers exist for the same property name with different required clases or value transformers that specifiy reverse transformed value types. It does so by applying with the first one that has the type of the required class or value transformer `reverseTransformedValueClass` type.
