### PR TITLE
Re-throw non-NSUndefinedKeyException exceptions when applying classes

### DIFF
--- a/Motif/Core/MTFThemeClass.h
+++ b/Motif/Core/MTFThemeClass.h
@@ -64,4 +64,11 @@ MTF_NS_ASSUME_NONNULL_BEGIN
  */
 extern NSString * const MTFThemeClassUnappliedPropertyException;
 
+/**
+ The user info key identifying the property name for which the class application
+ failed, as contained within the info of an 
+ MTFThemeClassUnappliedPropertyException
+ */
+extern NSString * const MTFThemeClassExceptionUserInfoKeyUnappliedPropertyName;
+
 MTF_NS_ASSUME_NONNULL_END

--- a/Motif/Core/MTFThemeClass.h
+++ b/Motif/Core/MTFThemeClass.h
@@ -58,4 +58,10 @@ MTF_NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+/**
+ The exception that is thrown when a property from a theme class is not able
+ to be applied to an object.
+ */
+extern NSString * const MTFThemeClassUnappliedPropertyException;
+
 MTF_NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This prevents the incorrect exception from being thrown when setting an Obj-C property of type MTFThemeClass that itself has properties that are unapplied. It fixes this by re-throwing the original exception, rather than always throwing.
