### PR TITLE
Parse floats in the range [0,1)

### DIFF
--- a/Motif/YAML Serialization/MTFYAMLSerialization.m
+++ b/Motif/YAML Serialization/MTFYAMLSerialization.m
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
         error:NULL];
 
     _floatRegularExpression = [NSRegularExpression
-        regularExpressionWithPattern:@"^(-?[1-9]\\d*(\\.\\d*)?(e[-+]?[1-9][0-9]+)?|0|inf|-inf|nan)$"
+        regularExpressionWithPattern:@"^(-?\\d+(\\.\\d*)?(e[-+]?\\d+)?|0|inf|-inf|nan)$"
         options:0
         error:NULL];
 


### PR DESCRIPTION
Currently, the parser things `0.5` is a string.
