### PR TITLE
Mark unavailable designated initializers as so

### DIFF
--- a/Motif/Core/MTFDynamicThemeApplier.h
+++ b/Motif/Core/MTFDynamicThemeApplier.h
@@ -28,6 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTFDynamicThemeApplier : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /**
  Initializes a dynamic theme applier with a theme.
  

--- a/Motif/Core/MTFDynamicThemeApplier.m
+++ b/Motif/Core/MTFDynamicThemeApplier.m
@@ -17,11 +17,7 @@
 #pragma mark - NSObject
 
 - (instancetype)init {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    // Ensure that exception is thrown when just `init` is called.
-    return [self initWithTheme:nil];
-#pragma clang diagnostic pop
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Use the designated initializer instead" userInfo:nil];
 }
 
 #pragma mark - MTFDynamicThemeApplier

--- a/Motif/Core/MTFFileObservationContext.h
+++ b/Motif/Core/MTFFileObservationContext.h
@@ -16,6 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTFFileObservationContext : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /**
  Initializes a file observation context.
  

--- a/Motif/Core/MTFFileObservationContext.m
+++ b/Motif/Core/MTFFileObservationContext.m
@@ -15,11 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - NSObject
 
 - (instancetype)init {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    // Ensure that exception is thrown when just `init` is called.
-    return [self initWithDispatchSource:NULL fileDescriptor:0 path:nil];
-#pragma clang diagnostic pop
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Use the designated initializer instead" userInfo:nil];
 }
 
 #pragma mark - MTFFileObservationContext

--- a/Motif/Core/MTFLiveReloadThemeApplier.h
+++ b/Motif/Core/MTFLiveReloadThemeApplier.h
@@ -19,6 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// access to the theme's source files within the same directory structure.
 @interface MTFLiveReloadThemeApplier : MTFDynamicThemeApplier
 
+- (instancetype)initWithTheme:(MTFTheme *)theme NS_UNAVAILABLE;
+
 /// Initializes a live reload theme applier using the __FILE__ directive.
 ///
 /// The file that this method is invoked from should not be at a higer directory

--- a/Motif/Core/MTFLiveReloadThemeApplier.m
+++ b/Motif/Core/MTFLiveReloadThemeApplier.m
@@ -22,11 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - MTFDynamicThemeApplier
 
 - (instancetype)initWithTheme:(MTFTheme *)theme {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    // Ensure that exception is thrown when just `initWithTheme:` is called.
-    return [self initWithTheme:theme sourceDirectoryURL:nil];
-#pragma clang diagnostic pop
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Use the designated initializer instead" userInfo:nil];
 }
 
 - (void)setTheme:(MTFTheme *)theme {

--- a/Motif/Core/MTFTheme.h
+++ b/Motif/Core/MTFTheme.h
@@ -34,6 +34,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTFTheme : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /**
  Creates a theme object from a theme file with the specified name.
  

--- a/Motif/Core/MTFTheme.m
+++ b/Motif/Core/MTFTheme.m
@@ -23,12 +23,7 @@ NSString * const MTFThemingErrorDomain = @"com.erichoracek.MTFTheming";
 #pragma mark - NSObject
 
 - (instancetype)init {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    // Ensure that exception is thrown when just `init` is called.
-    self = [self initWithFile:nil error:NULL];
-#pragma clang diagnostic pop
-    return self;
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Use the designated initializer instead" userInfo:nil];
 }
 
 #pragma mark - MTFTheme

--- a/Motif/Core/MTFThemeClass.h
+++ b/Motif/Core/MTFThemeClass.h
@@ -16,6 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTFThemeClass : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /**
  The name of the theme class, as specified in the theme file.
  */

--- a/Motif/Core/MTFThemeClass.m
+++ b/Motif/Core/MTFThemeClass.m
@@ -27,11 +27,7 @@ NSString * const MTFThemeClassExceptionUserInfoKeyUnappliedPropertyName = @"Prop
 #pragma mark - NSObject
 
 - (instancetype)init {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    // Ensure that exception is thrown when just `init` is called.
-    return [self initWithName:nil propertiesConstants:nil];
-#pragma clang diagnostic pop
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Use the designated initializer instead" userInfo:nil];
 }
 
 - (BOOL)isEqual:(id)object {

--- a/Motif/Core/MTFThemeClassApplier.h
+++ b/Motif/Core/MTFThemeClassApplier.h
@@ -13,6 +13,8 @@
  */
 @interface MTFThemeClassApplier : NSObject <MTFThemeClassApplicable>
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /**
  Initializes an theme class applier.
  

--- a/Motif/Core/MTFThemeClassApplier.m
+++ b/Motif/Core/MTFThemeClassApplier.m
@@ -13,12 +13,7 @@
 #pragma mark - NSObject
 
 - (instancetype)init {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    // Ensure that exception is thrown when just `init` is called.
-    self = [self initWithClassApplierBlock:nil];
-#pragma clang diagnostic pop
-    return self;
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Use the designated initializer instead" userInfo:nil];
 }
 
 #pragma mark - MTFThemeClassApplier

--- a/Motif/Core/MTFThemeClassPropertiesApplier.h
+++ b/Motif/Core/MTFThemeClassPropertiesApplier.h
@@ -14,6 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// to an object
 @interface MTFThemeClassPropertiesApplier : NSObject <MTFThemeClassApplicable>
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /**
  Initializes a theme class properties applier.
  
@@ -39,6 +41,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// An applier that is responsible for applying a set of theme class properties
 /// of specific types to an object.
 @interface MTFThemeClassTypedValuesPropertiesApplier : MTFThemeClassPropertiesApplier
+
+- (instancetype)initWithProperties:(NSArray *)properties applierBlock:(MTFThemePropertiesApplierBlock)applierBlock NS_UNAVAILABLE;
 
 /**
  Initializes a theme class properties applier.

--- a/Motif/Core/MTFThemeClassPropertiesApplier.m
+++ b/Motif/Core/MTFThemeClassPropertiesApplier.m
@@ -24,11 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Lifecycle
 
 - (instancetype)init {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    // Ensure that exception is thrown when just `init` is called.
-    return [self initWithProperties:nil applierBlock:nil];
-#pragma clang diagnostic pop
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Use the designated initializer instead" userInfo:nil];
 }
 
 - (instancetype)initWithProperties:(NSArray *)properties applierBlock:(MTFThemePropertiesApplierBlock)applierBlock {
@@ -87,11 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Lifecycle
 
 - (instancetype)initWithProperties:(NSArray *)properties applierBlock:(MTFThemePropertiesApplierBlock)applierBlock {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    // Ensure that exception is thrown when just `init` is called.
-    return [self initWithProperties:nil valueTypes:nil applierBlock:nil];
-#pragma clang diagnostic pop
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Use the designated initializer instead" userInfo:nil];
 }
 
 - (instancetype)initWithProperties:(NSArray *)properties valueTypes:(NSArray *)valueTypes applierBlock:(MTFThemePropertiesApplierBlock __nonnull)applierBlock {

--- a/Motif/Core/MTFThemeClassPropertyApplier.h
+++ b/Motif/Core/MTFThemeClassPropertyApplier.h
@@ -14,6 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// to an object.
 @interface MTFThemeClassPropertyApplier : NSObject <MTFThemeClassApplicable>
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Initializes a theme class property applier with a property name and an
 /// applier block.
 - (instancetype)initWithProperty:(NSString *)property applierBlock:(MTFThemePropertyApplierBlock)applierBlock NS_DESIGNATED_INITIALIZER;
@@ -31,6 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// An applier that is responsible for applying a specific theme class property
 /// of a certain class to an object.
 @interface MTFThemeClassValueClassPropertyApplier : MTFThemeClassPropertyApplier
+
+- (instancetype)initWithProperty:(NSString *)property applierBlock:(MTFThemePropertyApplierBlock)applierBlock NS_UNAVAILABLE;
 
 /// Initializes a theme class property applier with a property name, value
 /// class, and an applier block.
@@ -65,6 +69,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// An applier that is responsible for applying a specific theme class property
 /// of a certain Objective-C type to an object.
 @interface MTFThemeClassValueObjCTypePropertyApplier : MTFThemeClassPropertyApplier
+
+- (instancetype)initWithProperty:(NSString *)property applierBlock:(MTFThemePropertyApplierBlock)applierBlock NS_UNAVAILABLE;
 
 /// Initializes a theme class property applier with a property name, value
 /// Objective-C type, and an applier block.

--- a/Motif/Core/MTFThemeClassPropertyApplier.m
+++ b/Motif/Core/MTFThemeClassPropertyApplier.m
@@ -20,11 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Lifecycle
 
 - (instancetype)init {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    // Ensure that exception is thrown when just `init` is called.
-    return [self initWithProperty:nil applierBlock:nil];
-#pragma clang diagnostic pop
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Use the designated initializer instead" userInfo:nil];
 }
 
 - (instancetype)initWithProperty:(NSString *)property applierBlock:(MTFThemePropertyApplierBlock)applierBlock {
@@ -65,11 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Lifecycle
 
 - (instancetype)initWithProperty:(NSString *)property applierBlock:(MTFThemePropertyApplierBlock)applierBlock {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    // Ensure that exception is thrown when just `initWithProperty:applierBlock:` is called.
-    return [self initWithProperty:nil valueClass:nil applierBlock:nil];
-#pragma clang diagnostic pop
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Use the designated initializer instead" userInfo:nil];
 }
 
 - (instancetype)initWithProperty:(NSString *)property valueClass:(Class)valueClass applierBlock:(MTFThemePropertyApplierBlock)applierBlock {
@@ -131,11 +123,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Lifecycle
 
 - (instancetype)initWithProperty:(NSString *)property applierBlock:(MTFThemePropertyApplierBlock)applierBlock {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    // Ensure that exception is thrown when just `initWithProperty:applierBlock:` is called.
-    return [self initWithProperty:nil valueObjCType:NULL applierBlock:nil];
-#pragma clang diagnostic pop
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Use the designated initializer instead" userInfo:nil];
 }
 
 - (instancetype)initWithProperty:(NSString *)property valueObjCType:(const char *)valueObjCType applierBlock:(MTFThemePropertyApplierBlock)applierBlock {

--- a/Motif/Core/MTFThemeParser.m
+++ b/Motif/Core/MTFThemeParser.m
@@ -23,11 +23,7 @@
 #pragma mark - Public
 
 - (instancetype)init {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    // Ensure that exception is thrown when just `init` is called.
-    return [self initWithRawTheme:nil inheritingFromTheme:nil error:nil];
-#pragma clang diagnostic pop
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Use the designated initializer instead" userInfo:nil];
 }
 
 - (instancetype)initWithRawTheme:(NSDictionary *)rawTheme inheritingFromTheme:(MTFTheme *)theme error:(NSError *__autoreleasing *)error {

--- a/Motif/Core/MTFThemeSourceObserver.h
+++ b/Motif/Core/MTFThemeSourceObserver.h
@@ -20,6 +20,8 @@ typedef void (^MTFThemeDidUpdate)(MTFTheme *, NSError * null_resettable);
 /// new MTFTheme whenever they are edited.
 @interface MTFThemeSourceObserver : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Creates a theme source observer that observes the source of the specified
 /// theme, invoking the didUpdate block whenever a new theme is reloaded
 ///

--- a/Motif/Core/MTFThemeSourceObserver.m
+++ b/Motif/Core/MTFThemeSourceObserver.m
@@ -27,11 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - NSObject
 
 - (instancetype)init {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    // Ensure that exception is thrown when just `init` is called.
-    return [self initWithTheme:nil sourceDirectoryURL:nil didUpdate:nil];
-#pragma clang diagnostic pop
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Use the designated initializer instead" userInfo:nil];
 }
 
 - (void)dealloc {

--- a/Motif/YAML Serialization/MTFYAMLSerialization.h
+++ b/Motif/YAML Serialization/MTFYAMLSerialization.h
@@ -27,6 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// - Multiple documents http://yaml.org/spec/1.2/spec.html#id2800132
 @interface MTFYAMLSerialization : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Returns a Foundation object from given YAML data.
 ///
 /// @param data A data object containing YAML data.

--- a/Motif/YAML Serialization/MTFYAMLSerialization.m
+++ b/Motif/YAML Serialization/MTFYAMLSerialization.m
@@ -36,10 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Private
 
 - (instancetype)init {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    return [self initWithData:nil error:nil];
-#pragma clang diagnostic pop
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Use the designated initializer instead" userInfo:nil];
 }
 
 - (instancetype)initWithData:(NSData *)data error:(NSError *__autoreleasing *)error {

--- a/Motif/iOS Support/MTFScreenBrightnessThemeApplier.h
+++ b/Motif/iOS Support/MTFScreenBrightnessThemeApplier.h
@@ -22,6 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTFScreenBrightnessThemeApplier : MTFDynamicThemeApplier
 
+- (instancetype)initWithTheme:(MTFTheme *)theme NS_UNAVAILABLE;
+
 /**
  Initializes a screen brightness theme applier with the main screen.
  

--- a/Motif/iOS Support/MTFScreenBrightnessThemeApplier.m
+++ b/Motif/iOS Support/MTFScreenBrightnessThemeApplier.m
@@ -19,11 +19,7 @@
 #pragma mark - MTFDynamicThemeApplier
 
 - (instancetype)initWithTheme:(MTFTheme *)theme {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    // Ensure that exception is thrown when just `initWithTheme` is called.
-    return [self initWithScreen:nil lightTheme:nil darkTheme:nil];
-#pragma clang diagnostic pop
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Use the designated initializer instead" userInfo:nil];
     
 }
 

--- a/MotifTests/MTFLiveReloadThemeApplierTests.m
+++ b/MotifTests/MTFLiveReloadThemeApplierTests.m
@@ -56,10 +56,6 @@ static NSString * const PropertyValue2 = @"propertyValue2";
     XCTAssertTrue(didRemoveFile, @"Unable to remove file at location %@", self.sourceFileURL);
 }
 
-- (void)testThrowsOnInitialization {
-    XCTAssertThrows([[MTFLiveReloadThemeApplier alloc] init]);
-}
-
 - (void)testLiveReloadThemePropertyApplied {
     NSError *error;
     MTFTheme *theme = [[MTFTheme alloc] initWithFile:self.themeURL error:&error];

--- a/MotifTests/MTFScreenBrightnessThemeApplierTests.m
+++ b/MotifTests/MTFScreenBrightnessThemeApplierTests.m
@@ -95,10 +95,6 @@ static CGFloat TestScreenBrightness = 0.0f;
     XCTAssertThrows([applier setTheme:darkTheme], @"An exception should be thrown when invoking setTheme:");
 }
 
-- (void)testExceptionThrownWhenCreatedWithInit {
-    XCTAssertThrows([[MTFScreenBrightnessThemeApplier alloc] init], @"An exception should be thrown when invoking init");
-}
-
 @end
 
 @implementation TestScreen

--- a/MotifTests/MTFThemeClassApplierSpec.m
+++ b/MotifTests/MTFThemeClassApplierSpec.m
@@ -25,12 +25,6 @@ describe(@"lifecycle", ^{
 
         expect(applier.applierBlock).to.equal(applierBlock);
     });
-
-    it(@"should raise on initialization with init", ^{
-        expect(^{
-            __unused MTFThemeClassApplier *applier = [[MTFThemeClassApplier alloc] init];
-        }).to.raise(NSInternalInconsistencyException);
-    });
 });
 
 describe(@"application", ^{

--- a/MotifTests/MTFThemeClassPropertiesApplierSpec.m
+++ b/MotifTests/MTFThemeClassPropertiesApplierSpec.m
@@ -28,12 +28,6 @@ describe(@"lifecycle", ^{
         expect(applier.properties).to.equal(properties);
         expect(applier.applierBlock).to.equal(applierBlock);
     });
-
-    it(@"should raise on initialization with init", ^{
-        expect(^{
-            __unused id applier = [[MTFThemeClassPropertiesApplier alloc] init];
-        }).to.raise(NSInternalInconsistencyException);
-    });
 });
 
 describe(@"application", ^{
@@ -102,14 +96,6 @@ describe(@"lifecycle", ^{
         expect(applier.properties).to.equal(properties);
         expect(applier.valueTypes).to.equal(valueTypes);
         expect(applier.applierBlock).to.equal(applierBlock);
-    });
-
-    it(@"should raise on initialization with initWithProperties:applierBlock:", ^{
-        expect(^{
-            __unused id applier = [[MTFThemeClassTypedValuesPropertiesApplier alloc]
-                initWithProperties:@[@"property"]
-                applierBlock:^(NSDictionary *valuesForProperties, id objectToTheme){}];
-        }).to.raise(NSInternalInconsistencyException);
     });
 });
 

--- a/MotifTests/MTFThemeClassPropertyApplierSpec.m
+++ b/MotifTests/MTFThemeClassPropertyApplierSpec.m
@@ -28,12 +28,6 @@ describe(@"lifecycle", ^{
         expect(applier.property).to.equal(property);
         expect(applier.applierBlock).to.equal(applierBlock);
     });
-
-    it(@"should raise on initialization with init", ^{
-        expect(^{
-            __unused id applier = [[MTFThemeClassPropertyApplier alloc] init];
-        }).to.raise(NSInternalInconsistencyException);
-    });
 });
 
 describe(@"property application", ^{
@@ -99,12 +93,6 @@ describe(@"lifecycle", ^{
         expect(applier.valueClass).to.beIdenticalTo(valueClass);
         expect(applier.applierBlock).to.equal(applierBlock);
     });
-
-    it(@"should raise on initialization with initWithProperty:applierBlock:", ^{
-        expect(^{
-            __unused id applier = [[MTFThemeClassValueClassPropertyApplier alloc] initWithProperty:@"" applierBlock:^(id propertyValue, id objectToTheme) {}];
-        }).to.raise(NSInternalInconsistencyException);
-    });
 });
 
 describe(@"property application", ^{
@@ -169,12 +157,6 @@ describe(@"lifecycle", ^{
         expect(applier.property).to.equal(property);
         expect(@(applier.valueObjCType)).to.equal(@(valueObjCType));
         expect(applier.applierBlock).to.equal(applierBlock);
-    });
-
-    it(@"should raise on initialization with initWithProperty:applierBlock:", ^{
-        expect(^{
-            __unused id applier = [[MTFThemeClassValueObjCTypePropertyApplier alloc] initWithProperty:@"" applierBlock:^(id propertyValue, id objectToTheme) {}];
-        }).to.raise(NSInternalInconsistencyException);
     });
 });
 

--- a/MotifTests/MTFYAMLSerializationSpec.m
+++ b/MotifTests/MTFYAMLSerializationSpec.m
@@ -14,14 +14,6 @@
 
 SpecBegin(MTFYAMLSerialization)
 
-describe(@"lifecycle", ^{
-    it(@"should raise an exception on direct initalization", ^{
-        expect(^{
-            __unused MTFYAMLSerialization *serialization = [[MTFYAMLSerialization alloc] init];
-        }).to.raise(NSInternalInconsistencyException);
-    });
-});
-
 describe(@"deserialization from data", ^{
     __block NSError *error;
     __block MTFTheme *theme;


### PR DESCRIPTION
- Update tests to match
- Simplify exception throwing within unavailable designated initializers
