### PR TITLE
Resolve superclass references recursively rather than at init-time

### DIFF
--- a/Motif/Core/MTFTheme.m
+++ b/Motif/Core/MTFTheme.m
@@ -101,19 +101,13 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableDictionary<NSString *, MTFThemeClass *> *classes = [NSMutableDictionary dictionary];
 
     for (NSDictionary *dictionary in dictionaries) {
-        NSError *parseError;
         MTFThemeParser *parser = [[MTFThemeParser alloc]
             initWithRawTheme:dictionary
             inheritingExistingConstants:constants
             existingClasses:classes
-            error:&parseError];
+            error:error];
 
-        if (parseError != nil) {
-            if (error != NULL) {
-                *error = parseError;
-            }
-            return nil;
-        }
+        if (parser == nil) return nil;
 
         [constants addEntriesFromDictionary:parser.parsedConstants];
         [classes addEntriesFromDictionary:parser.parsedClasses];

--- a/Motif/Core/MTFThemeClass.h
+++ b/Motif/Core/MTFThemeClass.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  This dictionary is keyed by property names with values of the properties as
  values.
  */
-@property (nonatomic, copy, readonly) NSDictionary<NSString *, id> *properties;
+@property (nonatomic, copy, readonly, null_resettable) NSDictionary<NSString *, id> *properties;
 
 /**
  Applies the receiver to an object.

--- a/Motif/Core/MTFThemeClass_Private.h
+++ b/Motif/Core/MTFThemeClass_Private.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The resolved property constants across all superclasses.
  */
-@property (nonatomic, copy, readonly) NSDictionary<NSString *, MTFThemeConstant *> *resolvedPropertiesConstants;
+@property (nonatomic, copy, readonly, null_resettable) NSDictionary<NSString *, MTFThemeConstant *> *resolvedPropertiesConstants;
 
 @end
 

--- a/Motif/Core/MTFThemeParser.h
+++ b/Motif/Core/MTFThemeParser.h
@@ -36,9 +36,9 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param error A pass-by-reference error, populated if a parsing error occurred.
  
- @return An initialized theme parser.
+ @return An initialized theme parser, or nil if the parse failed.
  */
-- (instancetype)initWithRawTheme:(NSDictionary<NSString *, id> *)rawTheme inheritingExistingConstants:(NSDictionary<NSString *, MTFThemeConstant *> *)existingConstants existingClasses:(NSDictionary<NSString *, MTFThemeClass *> *)existingClasses error:(NSError **)error NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithRawTheme:(NSDictionary<NSString *, id> *)rawTheme inheritingExistingConstants:(NSDictionary<NSString *, MTFThemeConstant *> *)existingConstants existingClasses:(NSDictionary<NSString *, MTFThemeClass *> *)existingClasses error:(NSError **)error NS_DESIGNATED_INITIALIZER;
 
 /**
  The theme constants parsed from the raw theme.

--- a/Motif/Core/MTFThemeParser.m
+++ b/Motif/Core/MTFThemeParser.m
@@ -306,7 +306,7 @@ NS_ASSUME_NONNULL_BEGIN
     // Don't continue if there's no superclass, as it's the only reason why a
     // reference would be invalid
     MTFThemeClass *classSuperclass = [parsedConstants[MTFThemeSuperclassKey] referencedValue];
-    if (classSuperclass == nil) return parsedConstants;
+    if (classSuperclass == nil) return YES;
     
     // Ensure that no superclass all the way up the inheritance hierarchy
     // causes a circular reference.

--- a/Motif/Core/MTFThemeParser.m
+++ b/Motif/Core/MTFThemeParser.m
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
     @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Use the designated initializer instead" userInfo:nil];
 }
 
-- (instancetype)initWithRawTheme:(NSDictionary<NSString *, id> *)rawTheme inheritingExistingConstants:(NSDictionary<NSString *, MTFThemeConstant *> *)existingConstants existingClasses:(NSDictionary<NSString *, MTFThemeClass *> *)existingClasses error:(NSError **)error {
+- (nullable instancetype)initWithRawTheme:(NSDictionary<NSString *, id> *)rawTheme inheritingExistingConstants:(NSDictionary<NSString *, MTFThemeConstant *> *)existingConstants existingClasses:(NSDictionary<NSString *, MTFThemeClass *> *)existingClasses error:(NSError **)error {
     NSParameterAssert(rawTheme != nil);
     NSParameterAssert(existingConstants != nil);
     NSParameterAssert(existingClasses != nil);
@@ -40,54 +40,26 @@ NS_ASSUME_NONNULL_BEGIN
     // Filter out the constants and classes from the raw dictionary
     NSDictionary<NSString *, id> *rawConstants = [self rawConstantsFromRawTheme:rawTheme];
     NSDictionary<NSString *, id> *rawClasses = [self rawClassesFromRawTheme:rawTheme];
-    
-    // Determine the invalid keys from the raw theme
-    NSArray<NSString *> *invalidSymbols = [self
-        invalidSymbolsFromRawTheme:rawTheme
-        rawConstants:rawConstants
-        rawClasses:rawClasses];
-        
-    if (invalidSymbols.count && error) {
-        NSString *description = [NSString stringWithFormat:
-            @"The following theme symbols are invalid %@",
-            invalidSymbols];
 
-        *error = [NSError errorWithDomain:MTFErrorDomain code:MTFErrorFailedToParseTheme userInfo:@{
-            NSLocalizedDescriptionKey: description
-        }];
-    }
-    
-    // Map the constants from the raw theme
-    NSDictionary<NSString *, MTFThemeConstant *> *parsedConstants = [self
-        constantsParsedFromRawConstants:rawConstants
-        error:error];
+    if ([self rawThemeContainsInvalidSymbols:rawTheme rawConstants:rawConstants rawClasses:rawClasses error:error]) return nil;
 
-    NSDictionary<NSString *, MTFThemeClass *> *parsedClasses = [self
-        classesParsedFromRawClasses:rawClasses
-        error:error];
-    
+    NSDictionary<NSString *, MTFThemeConstant *> *parsedConstants = [self constantsParsedFromRawConstants:rawConstants];
+
+    NSDictionary<NSString *, MTFThemeClass *> *parsedClasses = [self classesParsedFromRawClasses:rawClasses error:error];
+    if (parsedClasses == nil) return nil;
+
     if (self.class.shouldResolveReferences) {
-        NSDictionary<NSString *, MTFThemeConstant *> *mergedConstants = [self
-            mergeParsedConstants:parsedConstants
-            intoExistingConstants:existingConstants
-            error:error];
+        NSDictionary<NSString *, MTFThemeConstant *> *mergedConstants = [self mergeParsedConstants:parsedConstants intoExistingConstants:existingConstants error:error];
+        if (mergedConstants == nil) return nil;
 
-        NSDictionary<NSString *, MTFThemeClass *> *mergedClasses = [self
-            mergeParsedClasses:parsedClasses
-            intoExistingClasses:existingClasses
-            error:error];
+        NSDictionary<NSString *, MTFThemeClass *> *mergedClasses = [self mergeParsedClasses:parsedClasses intoExistingClasses:existingClasses error:error];
+        if (mergedClasses == nil) return nil;
         
-        parsedConstants = [self
-            resolveReferencesInParsedConstants:parsedConstants
-            fromConstants:mergedConstants
-            classes:mergedClasses
-            error:error];
+        parsedConstants = [self resolveReferencesInParsedConstants:parsedConstants fromConstants:mergedConstants classes:mergedClasses error:error];
+        if (parsedConstants == nil) return nil;
         
-        parsedClasses = [self
-            resolveReferencesInParsedClasses:parsedClasses
-            fromConstants:mergedConstants
-            classes:mergedClasses
-            error:error];
+        parsedClasses = [self resolveReferencesInParsedClasses:parsedClasses fromConstants:mergedConstants classes:mergedClasses error:error];
+        if (parsedClasses == nil) return nil;
     }
     
     _parsedConstants = parsedConstants;
@@ -102,47 +74,67 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSDictionary<NSString *, id> *)rawConstantsFromRawTheme:(NSDictionary<NSString *, id> *)rawTheme {
     NSMutableDictionary *rawConstants = [NSMutableDictionary dictionary];
+
     for (NSString *symbol in rawTheme) {
         if (symbol.mtf_isRawSymbolConstantReference) {
             rawConstants[symbol] = rawTheme[symbol];
         }
     }
+
     return [rawConstants copy];
 }
 
 - (NSDictionary<NSString *, id> *)rawClassesFromRawTheme:(NSDictionary<NSString *, id> *)rawTheme {
     NSMutableDictionary *rawClasses = [NSMutableDictionary dictionary];
+
     for (NSString *symbol in rawTheme) {
         if (symbol.mtf_isRawSymbolClassReference) {
             rawClasses[symbol] = rawTheme[symbol];
         }
     }
+
     return [rawClasses copy];
 }
 
-- (NSArray<NSString *> *)invalidSymbolsFromRawTheme:(NSDictionary<NSString *, id> *)rawTheme rawConstants:(NSDictionary<NSString *, id> *)rawConstants rawClasses:(NSDictionary<NSString *, id> *)rawClasses {
+- (BOOL)rawThemeContainsInvalidSymbols:(NSDictionary<NSString *, id> *)rawTheme rawConstants:(NSDictionary<NSString *, id> *)rawConstants rawClasses:(NSDictionary<NSString *, id> *)rawClasses error:(NSError **)error {
     NSMutableSet<NSString *> *remainingKeys = [NSMutableSet setWithArray:rawTheme.allKeys];
     [remainingKeys minusSet:[NSSet setWithArray:rawConstants.allKeys]];
     [remainingKeys minusSet:[NSSet setWithArray:rawClasses.allKeys]];
-    return remainingKeys.allObjects;
+
+    if (remainingKeys.count > 0) {
+        if (error != NULL) {
+            NSString *description = [NSString stringWithFormat:
+                @"The following theme symbols are invalid %@",
+                remainingKeys];
+
+            *error = [NSError errorWithDomain:MTFErrorDomain code:MTFErrorFailedToParseTheme userInfo:@{
+                NSLocalizedDescriptionKey: description
+            }];
+        }
+
+        return YES;
+    }
+
+    return NO;
 }
 
 #pragma mark Constants
 
-- (NSDictionary<NSString *, MTFThemeConstant *> *)constantsParsedFromRawConstants:(NSDictionary *)rawConstants error:(NSError **)error {
+- (NSDictionary<NSString *, MTFThemeConstant *> *)constantsParsedFromRawConstants:(NSDictionary *)rawConstants {
     NSMutableDictionary *parsedConstants = [NSMutableDictionary dictionary];
+
     for (NSString *rawSymbol in rawConstants) {
         id rawValue = rawConstants[rawSymbol];
-        MTFThemeConstant *constant = [self
-            constantParsedFromRawSymbol:rawSymbol
-            rawValue:rawValue
-            error:error];
+
+        MTFThemeConstant *constant = [self constantParsedFromRawSymbol:rawSymbol rawValue:rawValue];
+
         parsedConstants[constant.name] = constant;
     };
+
     return [parsedConstants copy];
 }
 
-- (MTFThemeConstant *)constantParsedFromRawSymbol:(NSString *)rawSymbol rawValue:(id)rawValue error:(NSError **)error {
+- (MTFThemeConstant *)constantParsedFromRawSymbol:(NSString *)rawSymbol rawValue:(id)rawValue {
     // If the symbol is a reference (in the case of a root-level constant), use
     // it. Otherwise it is a reference to in a class' properties, so just keep
     // it as-is
@@ -165,8 +157,7 @@ NS_ASSUME_NONNULL_BEGIN
     
     // Determine if this string value is a symbol reference
     if (rawValueString.mtf_isRawSymbolReference) {
-        reference = [[MTFThemeSymbolReference alloc]
-            initWithRawSymbol:rawValueString];
+        reference = [[MTFThemeSymbolReference alloc] initWithRawSymbol:rawValueString];
     }
     
     return [[MTFThemeConstant alloc]
@@ -175,7 +166,7 @@ NS_ASSUME_NONNULL_BEGIN
         referencedValue:reference];
 }
 
-- (NSDictionary<NSString *, MTFThemeClass *> *)resolveReferencesInParsedClasses:(NSDictionary<NSString *, MTFThemeClass *> *)parsedClasses fromConstants:(NSDictionary<NSString *, MTFThemeConstant *> *)constants classes:(NSDictionary<NSString *, MTFThemeClass *> *)classes error:(NSError **)error {
+- (nullable NSDictionary<NSString *, MTFThemeClass *> *)resolveReferencesInParsedClasses:(NSDictionary<NSString *, MTFThemeClass *> *)parsedClasses fromConstants:(NSDictionary<NSString *, MTFThemeConstant *> *)constants classes:(NSDictionary<NSString *, MTFThemeClass *> *)classes error:(NSError **)error {
     NSMutableDictionary *resolvedClasses = [parsedClasses mutableCopy];
     NSArray<MTFThemeClass *> *parsedClassObjects = [parsedClasses objectEnumerator].allObjects;
     
@@ -186,6 +177,8 @@ NS_ASSUME_NONNULL_BEGIN
             fromConstants:constants
             classes:classes
             error:error];
+
+        if (propertiesConstants == nil) return nil;
         
         parsedClass.propertiesConstants = propertiesConstants;
     }
@@ -199,6 +192,8 @@ NS_ASSUME_NONNULL_BEGIN
             filterInvalidReferencesInParsedConstants:propertiesConstants
             forClass:resolvedClass
             error:error];
+
+        if (filteredPropertiesConstants == nil) return nil;
         
         resolvedClass.propertiesConstants = filteredPropertiesConstants;
     }
@@ -206,7 +201,7 @@ NS_ASSUME_NONNULL_BEGIN
     return [resolvedClasses copy];
 }
 
-- (NSDictionary *)resolveReferencesInParsedConstants:(NSDictionary<NSString *, MTFThemeConstant *> *)parsedConstants fromConstants:(NSDictionary<NSString *, MTFThemeConstant *> *)constants classes:(NSDictionary<NSString *, MTFThemeClass *> *)classes error:(NSError **)error {
+- (nullable NSDictionary *)resolveReferencesInParsedConstants:(NSDictionary<NSString *, MTFThemeConstant *> *)parsedConstants fromConstants:(NSDictionary<NSString *, MTFThemeConstant *> *)constants classes:(NSDictionary<NSString *, MTFThemeClass *> *)classes error:(NSError **)error {
     NSMutableDictionary *resolvedConstants = [parsedConstants mutableCopy];
     NSArray<MTFThemeConstant *> *parsedConstantObjects = [parsedConstants objectEnumerator].allObjects;
     
@@ -215,16 +210,12 @@ NS_ASSUME_NONNULL_BEGIN
             resolvedValueForThemeConstant:parsedConstant
             referenceHistory:@[ parsedConstant ]
             fromConstants:constants
-            classes:classes error:error];
+            classes:classes
+            error:error];
 
-        if (value != nil) {
-            parsedConstant.referencedValue = value;
-        }
-        // This is an invalid reference, so remove it from the resolved
-        // constants.
-        else {
-            [resolvedConstants removeObjectForKey:parsedConstant.name];
-        }
+        if (value == nil) return nil;
+
+        parsedConstant.referencedValue = value;
     }
     
     return [resolvedConstants copy];
@@ -314,7 +305,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (NSDictionary *)filterInvalidReferencesInParsedConstants:(NSDictionary *)parsedConstants forClass:(MTFThemeClass *)class error:(NSError **)error {
+- (nullable NSDictionary *)filterInvalidReferencesInParsedConstants:(NSDictionary *)parsedConstants forClass:(MTFThemeClass *)class error:(NSError **)error {
     // Don't continue if there's no superclass, as it's the only reason why a
     // reference would be invalid
     MTFThemeClass *classSuperclass = [parsedConstants[MTFThemeSuperclassKey] referencedValue];
@@ -345,7 +336,7 @@ NS_ASSUME_NONNULL_BEGIN
                 }];
             }
             
-            break;
+            return nil;
         }
         
     } while ((superclass = [superclass.propertiesConstants[MTFThemeSuperclassKey] referencedValue]));
@@ -355,62 +346,48 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark Classes
 
-- (NSDictionary<NSString *, MTFThemeClass *> *)classesParsedFromRawClasses:(NSDictionary *)rawClasses error:(NSError **)error {
+- (nullable NSDictionary<NSString *, MTFThemeClass *> *)classesParsedFromRawClasses:(NSDictionary *)rawClasses error:(NSError **)error {
     // Create MTFThemeClass objects from the raw classes
     NSMutableDictionary<NSString *, MTFThemeClass *> *parsedClasses = [NSMutableDictionary dictionary];
     
     for (NSString *rawClassName in rawClasses) {
         // Ensure that the raw properties are a dictionary and not another type
-        NSDictionary *rawProperties = [rawClasses
-            mtf_dictionaryValueForKey:rawClassName
-            error:error];
-        
-        if (rawProperties == nil) {
-            break;
-        }
+        NSDictionary *rawProperties = [rawClasses mtf_dictionaryValueForKey:rawClassName error:error];
+        if (rawProperties == nil) return nil;
         
         // Create a theme class from this properties dictionary
-        MTFThemeClass *class = [self
-            classParsedFromRawProperties:rawProperties
-            rawName:rawClassName
-            error:error];
-        
-        if (class != nil) {
-            parsedClasses[class.name] = class;
-        }
+        MTFThemeClass *class = [self classParsedFromRawProperties:rawProperties rawName:rawClassName error:error];
+        if (class == nil) return nil;
+
+        parsedClasses[class.name] = class;
     }
     
     return [parsedClasses copy];
 }
 
-- (MTFThemeClass *)classParsedFromRawProperties:(NSDictionary *)rawProperties rawName:(NSString *)rawName error:(NSError **)error {
+- (nullable MTFThemeClass *)classParsedFromRawProperties:(NSDictionary *)rawProperties rawName:(NSString *)rawName error:(NSError **)error {
     NSParameterAssert(rawName != nil);
     NSParameterAssert(rawProperties != nil);
     
     NSString *name = rawName.mtf_symbol;
 
-    NSDictionary *resolvedProperties = [self
-        constantsParsedFromRawConstants:rawProperties
-        error:error];
+    NSDictionary *resolvedProperties = [self constantsParsedFromRawConstants:rawProperties];
     
-    NSDictionary *filteredProperties = [self
-        filteredPropertiesFromResolvedClassProperties:resolvedProperties
-        className:name
-        error:error];
+    NSDictionary *filteredProperties = [self filteredPropertiesFromResolvedClassProperties:resolvedProperties className:name error:error];
+    if (filteredProperties == nil) return nil;
     
-    MTFThemeClass *class = [[MTFThemeClass alloc]
-        initWithName:name
-        propertiesConstants:filteredProperties];
+    MTFThemeClass *class = [[MTFThemeClass alloc] initWithName:name propertiesConstants:filteredProperties];
     
     return class;
 }
 
-- (NSDictionary *)filteredPropertiesFromResolvedClassProperties:(NSDictionary *)resolvedClassProperties className:(NSString *)className error:(NSError **)error {
+- (nullable NSDictionary *)filteredPropertiesFromResolvedClassProperties:(NSDictionary *)resolvedClassProperties className:(NSString *)className error:(NSError **)error {
     NSMutableDictionary *filteredClassProperties = [resolvedClassProperties mutableCopy];
     
     // If there is a superclass property, filter it out if it doesn't contain a
     // reference and populate the error
     MTFThemeConstant *superclass = filteredClassProperties[MTFThemeSuperclassKey];
+
     if (superclass != nil) {
         BOOL isSymbolReference = [superclass.referencedValue isKindOfClass:MTFThemeSymbolReference.class];
         BOOL isSuperclassClassReference = NO;
@@ -422,9 +399,6 @@ NS_ASSUME_NONNULL_BEGIN
         
         // If superclass property doesn't refer to a class, populate the error
         if (!isSuperclassClassReference || !isSymbolReference) {
-            // Filter this property out from this class' properties
-            [filteredClassProperties removeObjectForKey:MTFThemeSuperclassKey];
-            
             // Populate an error with the failure reason
             if (error != NULL) {
                 NSString *description = [NSString stringWithFormat:
@@ -437,6 +411,8 @@ NS_ASSUME_NONNULL_BEGIN
                     NSLocalizedDescriptionKey: description
                 }];
             }
+
+            return nil;
         }
     }
     
@@ -445,39 +421,49 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark Merging
 
-- (NSDictionary<NSString *, MTFThemeConstant *> *)mergeParsedConstants:(NSDictionary<NSString *, MTFThemeConstant *> *)parsedConstants intoExistingConstants:(NSDictionary<NSString *, MTFThemeConstant *> *)existingConstants error:(NSError **)error {
-    NSSet<NSString *> *intersectingConstants = [existingConstants
-        mtf_intersectingKeysWithDictionary:parsedConstants];
-    if (intersectingConstants.count && error) {
-        NSString *description = [NSString stringWithFormat:
-            @"Registering new constants with identical names to "
-                "previously-defined constants will overwrite existing "
-                "constants with the following names: %@",
-            intersectingConstants];
+- (nullable NSDictionary<NSString *, MTFThemeConstant *> *)mergeParsedConstants:(NSDictionary<NSString *, MTFThemeConstant *> *)parsedConstants intoExistingConstants:(NSDictionary<NSString *, MTFThemeConstant *> *)existingConstants error:(NSError **)error {
+    NSSet<NSString *> *intersectingConstants = [existingConstants mtf_intersectingKeysWithDictionary:parsedConstants];
 
-        *error = [NSError errorWithDomain:MTFErrorDomain code:MTFErrorFailedToParseTheme userInfo:@{
-            NSLocalizedDescriptionKey : description
-        }];
+    if (intersectingConstants.count > 0) {
+        if (error != NULL) {
+            NSString *description = [NSString stringWithFormat:
+                @"Registering new constants with identical names to "
+                    "previously-defined constants will overwrite existing "
+                    "constants with the following names: %@",
+                intersectingConstants];
+
+            *error = [NSError errorWithDomain:MTFErrorDomain code:MTFErrorFailedToParseTheme userInfo:@{
+                NSLocalizedDescriptionKey : description
+            }];
+        }
+
+        return nil;
     }
+
     NSMutableDictionary<NSString *, MTFThemeConstant *> *mergedConstants = [existingConstants mutableCopy];
     [mergedConstants addEntriesFromDictionary:parsedConstants];
     return [mergedConstants copy];
 }
 
-- (NSDictionary<NSString *, MTFThemeClass *> *)mergeParsedClasses:(NSDictionary<NSString *, MTFThemeClass *> *)parsedClasses intoExistingClasses:(NSDictionary<NSString *, MTFThemeClass *> *)existingClasses error:(NSError **)error {
-    NSSet<NSString *> *intersectingClasses = [existingClasses
-        mtf_intersectingKeysWithDictionary:parsedClasses];
-    if (intersectingClasses.count && error) {
-        NSString *description = [NSString stringWithFormat:
-            @"Registering new classes with identical names to "
-                "previously-defined classes will overwrite existing classes "
-                "with the following names: %@",
-            intersectingClasses];
-            
-        *error = [NSError errorWithDomain:MTFErrorDomain code:MTFErrorFailedToParseTheme userInfo:@{
-            NSLocalizedDescriptionKey : description
-        }];
+- (nullable NSDictionary<NSString *, MTFThemeClass *> *)mergeParsedClasses:(NSDictionary<NSString *, MTFThemeClass *> *)parsedClasses intoExistingClasses:(NSDictionary<NSString *, MTFThemeClass *> *)existingClasses error:(NSError **)error {
+    NSSet<NSString *> *intersectingClasses = [existingClasses mtf_intersectingKeysWithDictionary:parsedClasses];
+
+    if (intersectingClasses.count > 0) {
+        if (error != NULL) {
+            NSString *description = [NSString stringWithFormat:
+                @"Registering new classes with identical names to "
+                    "previously-defined classes will overwrite existing classes "
+                    "with the following names: %@",
+                intersectingClasses];
+                
+            *error = [NSError errorWithDomain:MTFErrorDomain code:MTFErrorFailedToParseTheme userInfo:@{
+                NSLocalizedDescriptionKey : description
+            }];
+        }
+
+        return nil;
     }
+
     NSMutableDictionary<NSString *, MTFThemeClass *> *mergedClasses = [existingClasses mutableCopy];
     [mergedClasses addEntriesFromDictionary:parsedClasses];
     return [mergedClasses copy];

--- a/Motif/Core/NSDictionary+DictionaryValueValidation.m
+++ b/Motif/Core/NSDictionary+DictionaryValueValidation.m
@@ -36,6 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
         }
         return nil;
     }
+
     return value;
 }
 


### PR DESCRIPTION
This fixes an issue where references could be resolved out-of-order.

Additionally clean up `MTFThemeParser` to not do extra work if parsing a theme failed.
